### PR TITLE
Increase requestTimeout to 4 mins

### DIFF
--- a/web.config
+++ b/web.config
@@ -61,7 +61,7 @@
         'processPath' setting can listen on this port.
                                                                                      
         -->
-        <httpPlatform processPath="d:\home\site\wwwroot\bin\apache-tomcat-8.5.24\bin\startup.bat" arguments="start">
+        <httpPlatform processPath="d:\home\site\wwwroot\bin\apache-tomcat-8.5.24\bin\startup.bat" arguments="start" requestTimeout="00:04:00">
             <environmentVariables>
                 <environmentVariable name="CATALINA_OPTS" value="-Dport.http=%HTTP_PLATFORM_PORT%" />
                 <environmentVariable name="CATALINA_HOME" value="d:\home\site\wwwroot\bin\apache-tomcat-8.5.24" />              


### PR DESCRIPTION
- Long running requests often result in a 502 due to the HttpPlatformHandler timing out.
- This change increases requestTimeout from the default value of 2 mins to 4 mins to match the front end's timeout value.